### PR TITLE
Fix typo

### DIFF
--- a/_src/config/structure.yml
+++ b/_src/config/structure.yml
@@ -690,7 +690,7 @@
       content:
         - source: "## String Utilities"
       children:
-        - title: "erb: Ruby Temlating"
+        - title: "erb: Ruby Templating"
           id: erb
           content:
             - source: "### ERB"


### PR DESCRIPTION
Just a little typo fix.

It's in `stdlib/string-utilities/erb.md` and `_data/book.yml` too, but perhaps they are generated from `_src/config/structure.yml`? I'm still getting my head around it.

This is awesome stuff, thanks.
